### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,10 +14,6 @@ ipdb
 jupyterlab
 PyPDF2
 PdfReader
-textract
-poppler-utils
-tesseract-ocr
-pycryptodome
 
 # tests/linter
 black


### PR DESCRIPTION
Got rid of textract, poppler-utils, tesseract-ocr and pycryptodome libraries as they are not needed right now.